### PR TITLE
Fix linter warnings

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -37,8 +37,8 @@ menu:
 
 params:
   BookTheme: "auto"
-  BookSection: docs # auto-switch dark/light
-  BookToC: false # show table of contents
+  BookSection: docs  # auto-switch dark/light
+  BookToC: false  # show table of contents
   BookDateFormat: "2006-01-02"
   BookSearch: true
   BookComments: false


### PR DESCRIPTION
## Summary
- fix inline comment spacing in `hugo.yaml`

## Testing
- `shellcheck bin/*.sh`
- `markdownlint-cli2 '**/*.md' '#node_modules'`
- `find . \( -path ./node_modules -o -path ./.git \) -prune -false -o \( -name '*.yaml' -o -name '*.yml' \) -print | xargs yamllint -c .yamllint`
- `bash tests/hugo_build_test.sh`
- ❌ `htmltest ./public` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb5d7bf04832bb828651a94eace33