### PR TITLE
Add yamllint config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get install -y yamllint
       - name: Run YAML linting
         run: |
-          find . \( -path ./node_modules -o -path ./.git \) -prune -false -o \( -name '*.yaml' -o -name '*.yml' \) -print | xargs yamllint -c .yamllint
+          find . \( -path ./node_modules -o -path ./.git \) -prune -false -o \( -name '*.yaml' -o -name '*.yml' \) -print | xargs yamllint -c .yamllint.yaml
 
       # Markdown link check
       - name: Install markdown-link-check

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,11 @@
+{
+  "projectBaseUrl": ".",
+  "replacementPatterns": [
+    { "pattern": "^/(.*)$", "replacement": "{{BASEURL}}/content/$1" },
+    { "pattern": "^./", "replacement": "{{BASEURL}}/" }
+  ],
+  "ignorePatterns": [
+    { "pattern": "101/$" },
+    { "pattern": "^mailto:" }
+  ]
+}

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no', 'on', 'off']
+    check-keys: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Contributor Covenant Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). By participating, you are expected to uphold this code. Please report unacceptable behavior to [maintainer@example.com](mailto:maintainer@example.com).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## 📖 About
 
-A personal knowledge base, blog, and developer log powered by [Hugo Book](<https://github.com/alex-shpak/hugo-book)> with seamless Vimwiki and Neovim integration.
+A personal knowledge base, blog, and developer log powered by [Hugo Book](https://github.com/alex-shpak/hugo-book) with seamless Vimwiki and Neovim integration.
 
 ---
 
@@ -40,10 +40,10 @@ A personal knowledge base, blog, and developer log powered by [Hugo Book](<https
 
 ### 1. Prerequisites
 
-- [Hugo Extended](<https://gohugo.io/getting-started/installing/)> `0.134+`
-- [git](<https://git-scm.com/)> (with submodule support)
-- [GNU Stow](<https://www.gnu.org/software/stow/)>
-- [Neovim](<https://neovim.io/)> with [Vimwiki](<https://github.com/vimwiki/vimwiki)>
+- [Hugo Extended](https://gohugo.io/getting-started/installing/) `0.134+`
+- [git](https://git-scm.com/) (with submodule support)
+- [GNU Stow](https://www.gnu.org/software/stow/)
+- [Neovim](https://neovim.io/) with [Vimwiki](https://github.com/vimwiki/vimwiki)
 
 ### 2. Install & Set Up
 
@@ -92,7 +92,7 @@ make build
 
 ## Local Pre-commit Hooks
 
-We use [pre-commit](<https://pre-commit.com/)> to auto-check Markdown and YAML code style before each commit.
+We use [pre-commit](https://pre-commit.com/) to auto-check Markdown and YAML code style before each commit.
 
 **Setup once:**
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -37,8 +37,8 @@ menu:
 
 params:
   BookTheme: "auto"
-  BookSection: docs # auto-switch dark/light
-  BookToC: false # show table of contents
+  BookSection: docs  # auto-switch dark/light
+  BookToC: false  # show table of contents
   BookDateFormat: "2006-01-02"
   BookSearch: true
   BookComments: false


### PR DESCRIPTION
## Summary
- add `.yamllint.yaml` so yamllint can find its config
- update CI workflow to use the new file

## Testing
- `shellcheck bin/*.sh`
- `markdownlint-cli2 '**/*.md' '#node_modules'`
- `find . \( -path ./node_modules -o -path ./.git \) -prune -false -o \( -name '*.yaml' -o -name '*.yml' \) -print | xargs yamllint -c .yamllint.yaml`
- `bash tests/hugo_build_test.sh`
- ❌ `htmltest ./public` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb5d7bf04832bb828651a94eace33